### PR TITLE
Give section 6 a header and paragraph

### DIFF
--- a/LICENSE-agreement.md
+++ b/LICENSE-agreement.md
@@ -44,4 +44,6 @@ If You redistribute this Work, include a copy of this Agreement and License with
 
 **c. Effective Date.**  This Agreement and License take effect on the day You copy, contribute to, or use the Work.
 
-## 6. This Agreement is a work of the U.S. Government and is not subject to copyright protection in the United States. Foreign copyrights may apply.
+## 6. Rights Protecting this Agreement
+
+This Agreement is a work of the U.S. Government and is not subject to copyright protection in the United States. Copyright protections may apply in other countries.


### PR DESCRIPTION
This closes #22.

*Assumptions*

I assumed:

- "foreign copyrights" was intended to compress the meaning to make the previous header as short as possible. As it is in a paragraph in this change set, I expanded it to "Copyright protections may apply in other countries."
- having "protection" 3 times ( when it could be reasonably be omitted ) is not a terrible thing because it is specific. 
- I knew what the intention of section 6 is. My idea about that might be incorrect in which case these changes may not work. 

