### PR TITLE
Tiered deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,14 @@ before_install:
 script:
 - "./cibuild"
 deploy:
+  before_deploy:
+  - if [[ -z "$TRAVIS_TAG" ]] ; then export BUCKET="beta.code.mil" ; else export BUCKET="www.code.mil" ; fi
   provider: s3
   on:
     branch: master
   access_key_id: "$ACCESS_KEY_ID"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY"
-  bucket: www.code.mil
+  bucket: "${BUCKET}"
   local_dir: _site
   skip_cleanup: true
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 - "./cibuild"
 deploy:
   before_deploy:
-  - if [[ -z "$TRAVIS_TAG" ]] ; then export BUCKET="beta.code.mil" ; else export BUCKET="www.code.mil" ; fi
+  - if [[ "$TRAVIS_TAG" =~ "^v[0-9]+\.[0-9]+\.[0-9]+" ]] ; then export BUCKET="www.code.mil" ; else export BUCKET="beta.code.mil" ; fi
   provider: s3
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ cache: bundler
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-branches:
-  only:
-  - master
 before_install:
 - gem update --system
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 - "./cibuild"
 deploy:
   before_deploy:
-  - if [[ "$TRAVIS_TAG" =~ "^v[0-9]+\.[0-9]+\.[0-9]+" ]] ; then export BUCKET="www.code.mil" ; else export BUCKET="beta.code.mil" ; fi
+  - if [[ "$TRAVIS_TAG" =~ "^v[0-9]+\.[0-9]+\.[0-9]+$" ]] ; then export BUCKET="www.code.mil" ; else export BUCKET="beta.code.mil" ; fi
   provider: s3
   on:
     branch: master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ When making your changes, it is highly encouraged that you use a [branch in Git]
 
 After review by the Code.mil team your PR will either be commented on with a request for more information or changes, or it will be merged into the codebase which will automatically deploy the changes to [beta.code.mil](http://beta.code.mil).
 
-Assuming everything checks out, the Code.mil team will deploy the changes to [code.mil](http://code.mil) by creating a [new release](https://github.com/deptofdefense/code.mil/releases/new) with a tag like vX.X.X (where X is between 0 and 9), human readable title, and any other relevent context in the description.
+Assuming everything checks out, the Code.mil team will deploy the changes to [code.mil](http://code.mil) by creating a [new release](https://github.com/deptofdefense/code.mil/releases/new) on master with a tag like vX.X.X (where X is between 0 and 9), human readable title, and any other relevent context in the description.
 
 ### Check Your Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Our Projects, Version 1.4
+# Contributing to Our Projects, Version 1.5
 
 **NOTE: This CONTRIBUTING.md is for software contributions. You do not need to follow the Developer's Certificate of Origin (DCO) process for commenting on the Code.mil repository documentation, such as CONTRIBUTING.md, INTENT.md, etc. or for submitting issues.**
 
@@ -129,7 +129,9 @@ When submitting a bug on the site please be sure to add extensive information ab
 
 When making your changes, it is highly encouraged that you use a [branch in Git](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging), then submit a [Pull Request (PR)](https://github.com/deptofdefense/move.mil/pulls) on GitHub. Your request will go through some automated checks using [Travis CI](https://travis-ci.org/deptofdefense/code.mil/), a continuous integration and deployment tool.
 
-After review by the Code.mil team your PR will either be commented on with a request for more information or changes, or it will be merged into the codebase which will automatically deploy the changes.
+After review by the Code.mil team your PR will either be commented on with a request for more information or changes, or it will be merged into the codebase which will automatically deploy the changes to [beta.code.mil](http://beta.code.mil).
+
+Assuming everything checks out, the Code.mil team will deploy the changes to [code.mil](http://code.mil).
 
 ### Check Your Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ When making your changes, it is highly encouraged that you use a [branch in Git]
 
 After review by the Code.mil team your PR will either be commented on with a request for more information or changes, or it will be merged into the codebase which will automatically deploy the changes to [beta.code.mil](http://beta.code.mil).
 
-Assuming everything checks out, the Code.mil team will deploy the changes to [code.mil](http://code.mil).
+Assuming everything checks out, the Code.mil team will deploy the changes to [code.mil](http://code.mil) by creating a [new release](https://github.com/deptofdefense/code.mil/releases/new) with a tag like vX.X.X (where X is between 0 and 9), human readable title, and any other relevent context in the description.
 
 ### Check Your Changes
 


### PR DESCRIPTION
Three important changes:
* All commits now run the build script on Travis CI
* All commits to master (pull request merges) will be deployed to beta.code.mil
* All releases on master will be deployed to www.code.mil

See instructions in CONTRIBUTING.md

#143