### PR TITLE
Enable public reads on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ deploy:
     bucket: "beta.code.mil"
     local_dir: _site
     skip_cleanup: true
+    acl: public_read
     on:
       branch: master
   - provider: s3
@@ -24,6 +25,7 @@ deploy:
     bucket: "www.code.mil"
     local_dir: _site
     skip_cleanup: true
+    acl: public_read
     on:
       condition: "$TRAVIS_TAG =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$"
 notifications:


### PR DESCRIPTION
Without this all deploys make the site unavailable when the content is overwritten in s3 and defaults to private

https://docs.travis-ci.com/user/deployment/s3/#S3-ACL-via-option