### PR TITLE
Add move.mil to code.json releases

### DIFF
--- a/code.json
+++ b/code.json
@@ -71,11 +71,6 @@
         "Sass",
         "JavaScript"
       ],
-      "partners": [
-        {
-          "name": "US Transportation Command"
-        }
-      ],
       "relatedCode": [
         {
           "name": "uswds-rails",

--- a/code.json
+++ b/code.json
@@ -38,7 +38,12 @@
       "repositoryURL": "https://github.com/deptofdefense/move.mil",
       "description": "The entry point website to the Defense Personal Property System (DPS).",
       "permissions": {
-        "licenses": [],
+        "licenses": [
+          {
+            "URL": "https://github.com/deptofdefense/move.mil/blob/master/LICENSE.md",
+            "name": "MIT"
+          }
+        ],
         "usageType": "openSource",
         "exemptionText": null
       },

--- a/code.json
+++ b/code.json
@@ -32,6 +32,58 @@
 				"created": "2017-02-12",
 				"metadataLastUpdated": "2018-01-23T15:00-04:00"
 			}
-		}
+		},
+    {
+      "name": "Move.mil",
+      "repositoryURL": "https://github.com/deptofdefense/move.mil",
+      "description": "The entry point website to the Defense Personal Property System (DPS).",
+      "permissions": {
+        "licenses": [],
+        "usageType": "openSource",
+        "exemptionText": null
+      },
+      "laborHours": 3000,
+      "tags": [
+        "Defense Personal Property System",
+        "US Transportation Command",
+        "USTRANSCOM",
+        "Defense Digital Service",
+        "DDS",
+        "Ruby",
+        "Ruby on Rails"
+      ],
+      "contact": {
+        "email": "move.mil@dds.mil"
+      },
+      "organization": "Defense Digital Service",
+      "status": "Production",
+      "vcs": "git",
+      "homepageURL": "https://move.mil",
+      "languages": [
+        "Ruby",
+        "Ruby on Rails",
+        "HTML",
+        "Sass",
+        "JavaScript"
+      ],
+      "partners": [
+        {
+          "name": "US Transportation Command"
+        }
+      ],
+      "relatedCode": [
+        {
+          "name": "uswds-rails",
+          "url": "https://github.com/jgarber623/uswds-rails",
+          "isGovernmentRepo": false
+        }
+      ],
+      "reusedCode": [
+        {
+          "name": "US Web Design System",
+          "url": "https://designsystem.digital.gov"
+        }
+      ]
+    }
 	]
 }


### PR DESCRIPTION
Using [the code inventory schema page on code.gov](https://code.gov/#/policy-guide/docs/compliance/inventory-code) as a guide, the change in this PR adds [the move.mil project](https://github.com/deptofdefense/move.mil) to `code.json`.

:us: 