### PR TITLE
fix typo #162

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
 
 - Copyright 2017 U.S. Federal Government (in countries where recognized) contact@dds.mil
 - Copyright 2018 William Entriken github.com@phor.net
+- Copyright 2018 Sean O'Shea sposhe.github@gmail.com
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
 
 ## Note for U.S. Federal Employees

--- a/_pages/how-to-open-source.md
+++ b/_pages/how-to-open-source.md
@@ -17,7 +17,7 @@ There are a few steps you will need to take to open source any project. Some of 
   <article class='usa-alert-body'>
     <h4 class='usa-alert-heading'>Is this process for you?</h4>
     <p class='usa-alert-text'>
-      This is one suggested workflow for opening sourcing an existing project (whether there is code or not yet), but you may want - or need - to follow a different process. Be sure to check with your organization to see if there is already a defined path to open source for you! If you aren't sure, send us an <a href='mailto:{{site.email}}'>email</a>!
+      This is one suggested workflow for open sourcing an existing project (whether there is code or not yet), but you may want - or need - to follow a different process. Be sure to check with your organization to see if there is already a defined path to open source for you! If you aren't sure, send us an <a href='mailto:{{site.email}}'>email</a>!
     </p>
   </article>
 </section>


### PR DESCRIPTION
Changed "opening sourcing" to "open sourcing" as described in #162 