### PR TITLE
Exclude dummy robots.txt file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,4 +23,5 @@ exclude:
   - 'Gemfile.lock'
   - 'Gemfile'
   - 'README.md'
+  - 'robots.txt-for-beta.code.mil'
   - 'vendor'


### PR DESCRIPTION
If this isn't renamed, then we don't need it